### PR TITLE
patchset: fix regression for vp9 decoding

### DIFF
--- a/patchset/0013-fftools-ffmpeg-support-variable-resolution-encode.patch
+++ b/patchset/0013-fftools-ffmpeg-support-variable-resolution-encode.patch
@@ -1,7 +1,7 @@
-From bde32858b04a5f5006360f23fae2f2d39871857e Mon Sep 17 00:00:00 2001
+From 183f39633b7a7f2648ef340eba9f659e7ae73807 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Wed, 31 Jul 2019 12:02:26 +0800
-Subject: [PATCH 13/28] fftools/ffmpeg: support variable resolution encode
+Subject: [PATCH] fftools/ffmpeg: support variable resolution encode
 
 Flush encoders when resolution change happens.
 
@@ -15,7 +15,7 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  2 files changed, 15 insertions(+)
 
 diff --git a/fftools/ffmpeg.c b/fftools/ffmpeg.c
-index def19c1..cd8f897 100644
+index 6385bde..99ac4e5 100644
 --- a/fftools/ffmpeg.c
 +++ b/fftools/ffmpeg.c
 @@ -130,6 +130,7 @@ static void do_video_stats(OutputStream *ost, int frame_size);
@@ -26,7 +26,7 @@ index def19c1..cd8f897 100644
  
  static int run_as_daemon  = 0;
  static int nb_frames_dup = 0;
-@@ -1068,6 +1069,19 @@ static void do_video_out(OutputFile *of,
+@@ -1078,6 +1079,19 @@ static void do_video_out(OutputFile *of,
      InputStream *ist = NULL;
      AVFilterContext *filter = ost->filter->filter;
  
@@ -47,14 +47,14 @@ index def19c1..cd8f897 100644
          ist = input_streams[ost->source_index];
  
 diff --git a/libavcodec/rawenc.c b/libavcodec/rawenc.c
-index d181b74..9e8cb57 100644
+index d181b74..0cccd21 100644
 --- a/libavcodec/rawenc.c
 +++ b/libavcodec/rawenc.c
 @@ -92,4 +92,5 @@ AVCodec ff_rawvideo_encoder = {
      .id             = AV_CODEC_ID_RAWVIDEO,
      .init           = raw_encode_init,
      .encode2        = raw_encode,
-+    .capabilities   = AV_CODEC_CAP_PARAM_CHANGE,
++    .capabilities   = AV_CODEC_CAP_PARAM_CHANGE | AV_CODEC_CAP_ENCODER_FLUSH,
  };
 -- 
 2.7.4


### PR DESCRIPTION
Add AV_CODEC_CAP_ENCODER_FLUSH for rawvideo encoder,
encoder is allowed to use avcodec_flush_buffers().

Added in 22b25b3ea5cf5e241e8dde5ddd107a3b1e6eb7a0.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>