### PR TITLE
patchset: correct SCC general_intra_constraint_flag

### DIFF
--- a/patchset/0062-FFmpeg-vaapi-HEVC-SCC-encode.patch
+++ b/patchset/0062-FFmpeg-vaapi-HEVC-SCC-encode.patch
@@ -1,4 +1,4 @@
-From 475603d9c72faf661f20aaad9235ab7e3e5cc699 Mon Sep 17 00:00:00 2001
+From f024b8e0ee0c873962d131388a05053791c90a60 Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Sun, 18 Oct 2020 16:15:37 -0400
 Subject: [PATCH] FFmpeg vaapi HEVC SCC encode.
@@ -21,15 +21,15 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
 ---
  libavcodec/avcodec.h           |  1 +
  libavcodec/vaapi_encode.c      |  1 +
- libavcodec/vaapi_encode_h265.c | 53 ++++++++++++++++++++++++++++------
+ libavcodec/vaapi_encode_h265.c | 56 ++++++++++++++++++++++++++++------
  libavutil/pixdesc.c            |  6 ++--
- 4 files changed, 48 insertions(+), 13 deletions(-)
+ 4 files changed, 50 insertions(+), 14 deletions(-)
 
 diff --git a/libavcodec/avcodec.h b/libavcodec/avcodec.h
-index e954bc8d53..d8760aea52 100644
+index f870da438f..4bbdb3740f 100644
 --- a/libavcodec/avcodec.h
 +++ b/libavcodec/avcodec.h
-@@ -1949,6 +1949,7 @@ typedef struct AVCodecContext {
+@@ -1961,6 +1961,7 @@ typedef struct AVCodecContext {
  #define FF_PROFILE_HEVC_MAIN_10                     2
  #define FF_PROFILE_HEVC_MAIN_STILL_PICTURE          3
  #define FF_PROFILE_HEVC_REXT                        4
@@ -38,7 +38,7 @@ index e954bc8d53..d8760aea52 100644
  #define FF_PROFILE_AV1_MAIN                         0
  #define FF_PROFILE_AV1_HIGH                         1
 diff --git a/libavcodec/vaapi_encode.c b/libavcodec/vaapi_encode.c
-index 4d2d7d37a6..e1bcc56e62 100644
+index 019d3dedfd..f561feb38d 100644
 --- a/libavcodec/vaapi_encode.c
 +++ b/libavcodec/vaapi_encode.c
 @@ -1255,6 +1255,7 @@ static const VAAPIEncodeRTFormat vaapi_encode_rt_formats[] = {
@@ -50,7 +50,7 @@ index 4d2d7d37a6..e1bcc56e62 100644
      { "YUV444",    VA_RT_FORMAT_YUV444,        8, 3, 0, 0 },
      { "YUV411",    VA_RT_FORMAT_YUV411,        8, 3, 2, 0 },
 diff --git a/libavcodec/vaapi_encode_h265.c b/libavcodec/vaapi_encode_h265.c
-index 4e5a7e65e6..19d68ac684 100644
+index 41d9968160..a246fe411d 100644
 --- a/libavcodec/vaapi_encode_h265.c
 +++ b/libavcodec/vaapi_encode_h265.c
 @@ -315,17 +315,13 @@ static int vaapi_encode_h265_init_sequence_params(AVCodecContext *avctx)
@@ -73,7 +73,17 @@ index 4e5a7e65e6..19d68ac684 100644
      ptl->general_max_12bit_constraint_flag = bit_depth <= 12;
      ptl->general_max_10bit_constraint_flag = bit_depth <= 10;
      ptl->general_max_8bit_constraint_flag  = bit_depth ==  8;
-@@ -540,6 +536,14 @@ static int vaapi_encode_h265_init_sequence_params(AVCodecContext *avctx)
+@@ -334,7 +330,8 @@ static int vaapi_encode_h265_init_sequence_params(AVCodecContext *avctx)
+     ptl->general_max_420chroma_constraint_flag  = chroma_format <= 1;
+     ptl->general_max_monochrome_constraint_flag = chroma_format == 0;
+ 
+-    ptl->general_intra_constraint_flag = ctx->gop_size == 1;
++    ptl->general_intra_constraint_flag =
++        (avctx->profile == FF_PROFILE_HEVC_SCC) ? 0 : ctx->gop_size == 1;
+ 
+     ptl->general_lower_bit_rate_constraint_flag = 1;
+ 
+@@ -530,6 +527,14 @@ static int vaapi_encode_h265_init_sequence_params(AVCodecContext *avctx)
      vui->log2_max_mv_length_horizontal = 15;
      vui->log2_max_mv_length_vertical   = 15;
  
@@ -88,7 +98,7 @@ index 4e5a7e65e6..19d68ac684 100644
  
      // PPS
  
-@@ -598,6 +602,12 @@ static int vaapi_encode_h265_init_sequence_params(AVCodecContext *avctx)
+@@ -588,6 +593,12 @@ static int vaapi_encode_h265_init_sequence_params(AVCodecContext *avctx)
  
      pps->pps_loop_filter_across_slices_enabled_flag = 1;
  
@@ -101,7 +111,7 @@ index 4e5a7e65e6..19d68ac684 100644
      // Fill VAAPI parameter buffers.
  
      *vseq = (VAEncSequenceParameterBufferHEVC) {
-@@ -653,6 +663,11 @@ static int vaapi_encode_h265_init_sequence_params(AVCodecContext *avctx)
+@@ -643,6 +654,11 @@ static int vaapi_encode_h265_init_sequence_params(AVCodecContext *avctx)
              sps->log2_diff_max_min_pcm_luma_coding_block_size,
  
          .vui_parameters_present_flag = 0,
@@ -113,7 +123,7 @@ index 4e5a7e65e6..19d68ac684 100644
      };
  
      *vpic = (VAEncPictureParameterBufferHEVC) {
-@@ -703,6 +718,10 @@ static int vaapi_encode_h265_init_sequence_params(AVCodecContext *avctx)
+@@ -693,6 +709,10 @@ static int vaapi_encode_h265_init_sequence_params(AVCodecContext *avctx)
              .enable_gpu_weighted_prediction = 0,
              .no_output_of_prior_pics_flag   = 0,
          },
@@ -124,7 +134,7 @@ index 4e5a7e65e6..19d68ac684 100644
      };
  
      if (pps->tiles_enabled_flag) {
-@@ -940,6 +959,7 @@ static int vaapi_encode_h265_init_slice_params(AVCodecContext *avctx,
+@@ -930,6 +950,7 @@ static int vaapi_encode_h265_init_slice_params(AVCodecContext *avctx,
      sh->slice_segment_address           = slice->block_start;
  
      sh->slice_type = hpic->slice_type;
@@ -132,7 +142,7 @@ index 4e5a7e65e6..19d68ac684 100644
      // driver requires low delay B frame in low power mode
      if (sh->slice_type == HEVC_SLICE_P && priv->b_frame_strategy)
          sh->slice_type = HEVC_SLICE_B;
-@@ -1031,8 +1051,14 @@ static int vaapi_encode_h265_init_slice_params(AVCodecContext *avctx,
+@@ -1021,8 +1042,14 @@ static int vaapi_encode_h265_init_slice_params(AVCodecContext *avctx,
              sh->collocated_ref_idx      = 0;
          }
  
@@ -149,7 +159,7 @@ index 4e5a7e65e6..19d68ac684 100644
          sh->num_ref_idx_l1_active_minus1 = pps->num_ref_idx_l1_default_active_minus1;
      }
  
-@@ -1054,7 +1080,9 @@ static int vaapi_encode_h265_init_slice_params(AVCodecContext *avctx,
+@@ -1044,7 +1071,9 @@ static int vaapi_encode_h265_init_slice_params(AVCodecContext *avctx,
          .slice_type                 = sh->slice_type,
          .slice_pic_parameter_set_id = sh->slice_pic_parameter_set_id,
  
@@ -160,7 +170,7 @@ index 4e5a7e65e6..19d68ac684 100644
          .num_ref_idx_l1_active_minus1 = sh->num_ref_idx_l1_active_minus1,
  
          .luma_log2_weight_denom         = sh->luma_log2_weight_denom,
-@@ -1183,6 +1211,12 @@ static const VAAPIEncodeProfile vaapi_encode_h265_profiles[] = {
+@@ -1173,6 +1202,12 @@ static const VAAPIEncodeProfile vaapi_encode_h265_profiles[] = {
      { FF_PROFILE_HEVC_REXT,    12, 3, 1, 1, VAProfileHEVCMain12     },
      { FF_PROFILE_HEVC_REXT,    12, 3, 1, 0, VAProfileHEVCMain422_12 },
      { FF_PROFILE_HEVC_REXT,    12, 3, 0, 0, VAProfileHEVCMain444_12 },
@@ -173,7 +183,7 @@ index 4e5a7e65e6..19d68ac684 100644
  #endif
  
      { FF_PROFILE_UNKNOWN }
-@@ -1304,6 +1338,7 @@ static const AVOption vaapi_encode_h265_options[] = {
+@@ -1294,6 +1329,7 @@ static const AVOption vaapi_encode_h265_options[] = {
      { PROFILE("main",               FF_PROFILE_HEVC_MAIN) },
      { PROFILE("main10",             FF_PROFILE_HEVC_MAIN_10) },
      { PROFILE("rext",               FF_PROFILE_HEVC_REXT) },


### PR DESCRIPTION
According to spec A.5, general_intra_constraint_flag this flag
will be set to 0 for all SCC profile.

Signed-off-by: Fei Wang <fei.w.wang@intel.com>